### PR TITLE
🩹 [Patch]: Verify that `vcruntime140` is installed on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,6 @@ PublicKey PrivateKey
 WQakMx2mIAQMwLqiZteHUTwmMP6mUdK2FL0WEybWgB8= ci5/7eZ0IbGXtqQMaNvxhJ2d9qwFxA8Kjx+vivSTXqU=
 ```
 
-
-
 ### Example 3: Encrypt a message using a public key (Sealed Boxes encryption)
 
 After generating a key pair, a message can be encrypted using the associated public key with [Sealed Boxes encryption](https://doc.libsodium.org/public-key_cryptography/sealed_boxes).

--- a/src/functions/private/Assert-VisualCRedistributableInstalled.ps1
+++ b/src/functions/private/Assert-VisualCRedistributableInstalled.ps1
@@ -1,0 +1,47 @@
+function Assert-VisualCRedistributableInstalled {
+    <#
+        .SYNOPSIS
+        Determines if a version of the Visual C++ Redistributable is installed and meets the specified minimum version.
+
+        .DESCRIPTION
+        This function checks whether the Visual C++ Redistributable for Visual Studio 2015 or later is installed on
+        the system and ensures that the installed version is greater than or equal to the specified minimum version.
+        If the required version is not found, a warning is displayed, suggesting where to download the latest
+        redistributable package.
+
+        .EXAMPLE
+        Assert-VisualCRedistributableInstalled -Version '14.29.30037'
+
+        Output:
+        ```powershell
+        True
+        ```
+
+        Checks if the installed Visual C++ Redistributable version is at least 14.29.30037 and returns `$true`
+        if the requirement is met.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param (
+        # The minimum required version of the Visual C++ Redistributable.
+        [Parameter(Mandatory)]
+        [Version] $Version
+    )
+
+    process {
+        $result = $false
+        if ($IsWindows) {
+            $key = 'HKLM:\SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\X64'
+            if (Test-Path -Path $key) {
+                $installedVersion = (Get-ItemProperty -Path $key).Version
+                $result = [Version]($installedVersion.SubString(1, $installedVersion.Length - 1)) -ge $Version
+            }
+        }
+        if (-not $result) {
+            Write-Warning 'The Visual C++ Redistributable for Visual Studio 2015 or later is required.'
+            Write-Warning 'Download and install the appropriate version from:'
+            Write-Warning ' - https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads'
+        }
+        $result
+    }
+}

--- a/src/functions/public/ConvertFrom-SodiumSealedBox.ps1
+++ b/src/functions/public/ConvertFrom-SodiumSealedBox.ps1
@@ -41,6 +41,7 @@
     )
 
     begin {
+        if (-not $script:Supported) { throw 'Sodium is not supported on this platform.' }
         $null = [PSModule.Sodium]::sodium_init()
     }
 

--- a/src/functions/public/ConvertTo-SodiumSealedBox.ps1
+++ b/src/functions/public/ConvertTo-SodiumSealedBox.ps1
@@ -30,6 +30,7 @@
         [string] $PublicKey
     )
     begin {
+        if (-not $script:Supported) { throw 'Sodium is not supported on this platform.' }
         $null = [PSModule.Sodium]::sodium_init()
     }
 

--- a/src/functions/public/New-SodiumKeyPair.ps1
+++ b/src/functions/public/New-SodiumKeyPair.ps1
@@ -57,6 +57,7 @@
     )
 
     begin {
+        if (-not $script:Supported) { throw 'Sodium is not supported on this platform.' }
         $null = [PSModule.Sodium]::sodium_init()
     }
 

--- a/src/main.ps1
+++ b/src/main.ps1
@@ -1,6 +1,7 @@
 switch ($true) {
     $IsLinux {
         Import-Module "$PSScriptRoot/libs/linux-x64/PSModule.Sodium.dll"
+        $script:Supported = $true
     }
     $IsMacOS {
         if ("$(sysctl -n machdep.cpu.brand_string)" -Like 'Apple*') {
@@ -8,6 +9,7 @@ switch ($true) {
         } else {
             Import-Module "$PSScriptRoot/libs/osx-x64/PSModule.Sodium.dll"
         }
+        $script:Supported = $true
     }
     $IsWindows {
         if ([System.Environment]::Is64BitProcess) {
@@ -15,6 +17,7 @@ switch ($true) {
         } else {
             Import-Module "$PSScriptRoot/libs/win-x86/PSModule.Sodium.dll"
         }
+        $script:Supported = Assert-VisualCRedistributableInstalled -Version '14.29.30037'
     }
     default {
         throw 'Unsupported platform. Please refer to the documentation for more information.'

--- a/src/main.ps1
+++ b/src/main.ps1
@@ -17,7 +17,7 @@ switch ($true) {
         } else {
             Import-Module "$PSScriptRoot/libs/win-x86/PSModule.Sodium.dll"
         }
-        $script:Supported = Assert-VisualCRedistributableInstalled -Version '14.29.30037'
+        $script:Supported = Assert-VisualCRedistributableInstalled -Version '14.0'
     }
     default {
         throw 'Unsupported platform. Please refer to the documentation for more information.'

--- a/src/variables/private/Supported.ps1
+++ b/src/variables/private/Supported.ps1
@@ -1,0 +1,1 @@
+﻿$script:Supported = $false


### PR DESCRIPTION
## Description

- Fixes #13

This pull request includes several changes to improve platform compatibility and ensure the necessary dependencies are installed. The most important changes include adding a new function to check for the Visual C++ Redistributable, updating scripts to verify platform support, and initializing the Sodium library conditionally.

### Platform compatibility improvements:

* [`src/functions/private/Assert-VisualCRedistributableInstalled.ps1`](diffhunk://#diff-35f6fe814179c7dc7dbe445edfeaec04e40ead8fd994ff12ff293aa5f6883d6dR1-R47): Added a new function `Assert-VisualCRedistributableInstalled` to check if the Visual C++ Redistributable for Visual Studio 2015 or later is installed and meets the specified minimum version.
* [`src/main.ps1`](diffhunk://#diff-75cbc94876914e3617b466284eb14da2baf68299fb67315e8a5a2f6f1c38ab3fR4-R20): Modified the main script to set the `$script:Supported` variable based on platform checks and the result of `Assert-VisualCRedistributableInstalled` for Windows.
* [`src/variables/private/Supported.ps1`](diffhunk://#diff-7904f48b2851050ac94d151a468c3e9f107ca59a76c6297d8dfe3adaee8837daR1): Added a new variable `$script:Supported` initialized to `$false` to track platform support status.

### Sodium library initialization:

* `src/functions/public/ConvertFrom-SodiumSealedBox.ps1`, `src/functions/public/ConvertTo-SodiumSealedBox.ps1`, `src/functions/public/New-SodiumKeyPair.ps1`: Updated these scripts to throw an error if Sodium is not supported on the platform by checking the `$script:Supported` variable before initializing the Sodium library. [[1]](diffhunk://#diff-afea5aa86ab4622c3a4bff63aa61976494cb620d338df534bf7121018056bbadR44) [[2]](diffhunk://#diff-be3e1727721972ed3d4275a880537b89ce6fbb16c1d97405e02d7e798b6c7bfbR33) [[3]](diffhunk://#diff-b951668ffde5fc1b700af8f8b2b6076d7ce27b0ec23e9d556ad1a893e204c87bR60)

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
