### PR TITLE
🩹 [Patch]: Support pipeline input on `ConvertTo-` and `ConvertFrom-SodiumSealedBox` and `New-SodiumKeyPair`

### DIFF
--- a/src/functions/public/ConvertFrom-SodiumSealedBox.ps1
+++ b/src/functions/public/ConvertFrom-SodiumSealedBox.ps1
@@ -35,6 +35,7 @@
         .OUTPUTS
         System.String
 
+        .NOTES
         Returns the original plaintext string after decryption.
         If decryption fails, an exception is thrown.
 

--- a/src/functions/public/ConvertFrom-SodiumSealedBox.ps1
+++ b/src/functions/public/ConvertFrom-SodiumSealedBox.ps1
@@ -33,7 +33,10 @@
         Uses pipeline input to decrypt the given encrypted message with the specified keys.
 
         .OUTPUTS
-        System.String. Returns the original plaintext string after decryption.
+        System.String.
+
+        .NOTES
+        Returns the original plaintext string after decryption.
         If decryption fails, an exception is thrown.
 
         .LINK

--- a/src/functions/public/ConvertFrom-SodiumSealedBox.ps1
+++ b/src/functions/public/ConvertFrom-SodiumSealedBox.ps1
@@ -33,10 +33,7 @@
         Uses pipeline input to decrypt the given encrypted message with the specified keys.
 
         .OUTPUTS
-        System.String
-
-        .NOTES
-        Returns the original plaintext string after decryption.
+        System.String. Returns the original plaintext string after decryption.
         If decryption fails, an exception is thrown.
 
         .LINK

--- a/src/functions/public/ConvertFrom-SodiumSealedBox.ps1
+++ b/src/functions/public/ConvertFrom-SodiumSealedBox.ps1
@@ -15,7 +15,28 @@
         }
         ConvertFrom-SodiumSealedBox @params
 
+        Output:
+        ```powershell
+        Secret message revealed!
+        ```
+
         Decrypts the given encrypted message using the specified public and private keys and returns the original string.
+
+        .EXAMPLE
+        $encryptedMessage | ConvertFrom-SodiumSealedBox -PublicKey $publicKey -PrivateKey $privateKey
+
+        Output:
+        ```powershell
+        Confidential Data
+        ```
+
+        Uses pipeline input to decrypt the given encrypted message with the specified keys.
+
+        .OUTPUTS
+        System.String
+
+        Returns the original plaintext string after decryption.
+        If decryption fails, an exception is thrown.
 
         .LINK
         https://psmodule.io/Sodium/Functions/ConvertFrom-SodiumSealedBox/
@@ -27,7 +48,11 @@
     [CmdletBinding()]
     param(
         # The base64-encoded encrypted secret string to decrypt.
-        [Parameter(Mandatory)]
+        [Parameter(
+            Mandatory,
+            ValueFromPipeline,
+            ValueFromPipelineByPropertyName
+        )]
         [Alias('CipherText')]
         [string] $SealedBox,
 

--- a/src/functions/public/ConvertFrom-SodiumSealedBox.ps1
+++ b/src/functions/public/ConvertFrom-SodiumSealedBox.ps1
@@ -33,7 +33,7 @@
         Uses pipeline input to decrypt the given encrypted message with the specified keys.
 
         .OUTPUTS
-        System.String.
+        System.String
 
         .NOTES
         Returns the original plaintext string after decryption.

--- a/src/functions/public/ConvertTo-SodiumSealedBox.ps1
+++ b/src/functions/public/ConvertTo-SodiumSealedBox.ps1
@@ -30,6 +30,7 @@
         .OUTPUTS
         System.String
 
+        .NOTES
         The function returns a base64-encoded sealed box string that can only be decrypted by the corresponding private key.
 
         .LINK

--- a/src/functions/public/ConvertTo-SodiumSealedBox.ps1
+++ b/src/functions/public/ConvertTo-SodiumSealedBox.ps1
@@ -8,9 +8,29 @@
         The result is a base64-encoded sealed box that can only be decrypted by the corresponding private key.
 
         .EXAMPLE
-        ConvertTo-SodiumSealedBox -Message "Hello world!" -PublicKey "BASE64_PUBLIC_KEY"
+        ConvertTo-SodiumSealedBox -Message "Hello world!" -PublicKey $publicKey
+
+        Output:
+        ```powershell
+        hhCon4PO1X0TIPeh1i4GM6Wg9HSF5ge/x4L7p1vNd3lIdiJqNmBfswkcHipyM4HUr9wDLebjARVp5tsB
+        ```
 
         Encrypts the message "Hello world!" using the provided base64-encoded public key and returns a base64-encoded sealed box.
+
+        .EXAMPLE
+        "Sensitive Data" | ConvertTo-SodiumSealedBox -PublicKey $publicKey
+
+        Output:
+        ```powershell
+        p3PGL162uLCvrsCRLUDrc/Kfc5biGVzxRDg25ZdJoR9Y6ABZUKo8pvDoOGdchv0iBYQO2LP0Q6BkVbIDBUw=
+        ```
+
+        Uses pipeline input to encrypt the provided message using the specified public key.
+
+        .OUTPUTS
+        System.String
+
+        The function returns a base64-encoded sealed box string that can only be decrypted by the corresponding private key.
 
         .LINK
         https://psmodule.io/Sodium/Functions/ConvertTo-SodiumSealedBox/
@@ -22,7 +42,11 @@
     [CmdletBinding()]
     param(
         # The message string to be encrypted.
-        [Parameter(Mandatory)]
+        [Parameter(
+            Mandatory,
+            ValueFromPipeline,
+            ValueFromPipelineByPropertyName
+        )]
         [string] $Message,
 
         # The base64-encoded public key used for encryption.

--- a/src/functions/public/ConvertTo-SodiumSealedBox.ps1
+++ b/src/functions/public/ConvertTo-SodiumSealedBox.ps1
@@ -28,10 +28,7 @@
         Uses pipeline input to encrypt the provided message using the specified public key.
 
         .OUTPUTS
-        System.String
-
-        .NOTES
-        The function returns a base64-encoded sealed box string that can only be decrypted by the corresponding private key.
+        System.String. The function returns a base64-encoded sealed box string that can only be decrypted by the corresponding private key.
 
         .LINK
         https://psmodule.io/Sodium/Functions/ConvertTo-SodiumSealedBox/

--- a/src/functions/public/ConvertTo-SodiumSealedBox.ps1
+++ b/src/functions/public/ConvertTo-SodiumSealedBox.ps1
@@ -28,7 +28,7 @@
         Uses pipeline input to encrypt the provided message using the specified public key.
 
         .OUTPUTS
-        System.String.
+        System.String
 
         .NOTES
         The function returns a base64-encoded sealed box string that can only be decrypted by the corresponding private key.

--- a/src/functions/public/ConvertTo-SodiumSealedBox.ps1
+++ b/src/functions/public/ConvertTo-SodiumSealedBox.ps1
@@ -28,7 +28,10 @@
         Uses pipeline input to encrypt the provided message using the specified public key.
 
         .OUTPUTS
-        System.String. The function returns a base64-encoded sealed box string that can only be decrypted by the corresponding private key.
+        System.String.
+
+        .NOTES
+        The function returns a base64-encoded sealed box string that can only be decrypted by the corresponding private key.
 
         .LINK
         https://psmodule.io/Sodium/Functions/ConvertTo-SodiumSealedBox/

--- a/src/functions/public/New-SodiumKeyPair.ps1
+++ b/src/functions/public/New-SodiumKeyPair.ps1
@@ -37,6 +37,15 @@
         Generates a deterministic key pair using the given seed string. The same seed will produce
         the same key pair every time.
 
+        .OUTPUTS
+        pscustomobject
+
+        Returns a PowerShell custom object with the following properties:
+        - **PublicKey**:  The base64-encoded public key.
+        - **PrivateKey**: The base64-encoded private key.
+
+        If key generation fails, an exception is thrown.
+
         .LINK
         https://psmodule.io/Sodium/Functions/New-SodiumKeyPair/
 

--- a/src/functions/public/New-SodiumKeyPair.ps1
+++ b/src/functions/public/New-SodiumKeyPair.ps1
@@ -38,10 +38,8 @@
         the same key pair every time.
 
         .OUTPUTS
-        pscustomobject.
 
-        .NOTES
-        Returns a PowerShell custom object with the following properties:
+        pscustomobject. Returns a PowerShell custom object with the following properties:
         - **PublicKey**:  The base64-encoded public key.
         - **PrivateKey**: The base64-encoded private key.
         If key generation fails, an exception is thrown.

--- a/src/functions/public/New-SodiumKeyPair.ps1
+++ b/src/functions/public/New-SodiumKeyPair.ps1
@@ -40,6 +40,7 @@
         .OUTPUTS
         pscustomobject
 
+        .NOTES
         Returns a PowerShell custom object with the following properties:
         - **PublicKey**:  The base64-encoded public key.
         - **PrivateKey**: The base64-encoded private key.

--- a/src/functions/public/New-SodiumKeyPair.ps1
+++ b/src/functions/public/New-SodiumKeyPair.ps1
@@ -39,7 +39,10 @@
 
         .OUTPUTS
 
-        pscustomobject. Returns a PowerShell custom object with the following properties:
+        PSCustomObject
+
+        .NOTES
+        Returns a PowerShell custom object with the following properties:
         - **PublicKey**:  The base64-encoded public key.
         - **PrivateKey**: The base64-encoded private key.
         If key generation fails, an exception is thrown.
@@ -55,7 +58,7 @@
         Scope = 'Function',
         Justification = 'Does not change state'
     )]
-    [OutputType([pscustomobject])]
+    [OutputType([PSCustomObject])]
     [CmdletBinding(DefaultParameterSetName = 'NewKeyPair')]
     param(
         # A seed value to use for key generation.

--- a/src/functions/public/New-SodiumKeyPair.ps1
+++ b/src/functions/public/New-SodiumKeyPair.ps1
@@ -37,6 +37,19 @@
         Generates a deterministic key pair using the given seed string. The same seed will produce
         the same key pair every time.
 
+        .EXAMPLE
+        "MySecureSeed" | New-SodiumKeyPair
+
+        Output:
+        ```powershell
+        PublicKey                                    PrivateKey
+        ---------                                    ----------
+        WQakMx2mIAQMwLqiZteHUTwmMP6mUdK2FL0WEybWgB8= ci5/7eZ0IbGXtqQMaNvxhJ2d9qwFxA8Kjx+vivSTXqU=
+        ```
+
+        Generates a deterministic key pair using the given seed string via pipeline. The same seed will produce
+        the same key pair every time.
+
         .OUTPUTS
 
         PSCustomObject
@@ -62,7 +75,11 @@
     [CmdletBinding(DefaultParameterSetName = 'NewKeyPair')]
     param(
         # A seed value to use for key generation.
-        [Parameter(Mandatory, ParameterSetName = 'SeededKeyPair')]
+        [Parameter(
+            Mandatory,
+            ParameterSetName = 'SeededKeyPair',
+            ValueFromPipeline
+        )]
         [string] $Seed
     )
 

--- a/src/functions/public/New-SodiumKeyPair.ps1
+++ b/src/functions/public/New-SodiumKeyPair.ps1
@@ -38,13 +38,9 @@
         the same key pair every time.
 
         .OUTPUTS
-        pscustomobject
-
-        .NOTES
-        Returns a PowerShell custom object with the following properties:
+        pscustomobject. Returns a PowerShell custom object with the following properties:
         - **PublicKey**:  The base64-encoded public key.
         - **PrivateKey**: The base64-encoded private key.
-
         If key generation fails, an exception is thrown.
 
         .LINK

--- a/src/functions/public/New-SodiumKeyPair.ps1
+++ b/src/functions/public/New-SodiumKeyPair.ps1
@@ -38,7 +38,10 @@
         the same key pair every time.
 
         .OUTPUTS
-        pscustomobject. Returns a PowerShell custom object with the following properties:
+        pscustomobject.
+
+        .NOTES
+        Returns a PowerShell custom object with the following properties:
         - **PublicKey**:  The base64-encoded public key.
         - **PrivateKey**: The base64-encoded private key.
         If key generation fails, an exception is thrown.

--- a/tests/Sodium.Tests.ps1
+++ b/tests/Sodium.Tests.ps1
@@ -113,6 +113,15 @@
             $keyPair1.PrivateKey | Should -Be $keyPair2.PrivateKey
         }
 
+        It 'Generates deterministic keys when a seed is provided - using a pipeline input' {
+            $seed = 'DeterministicSeed'
+            $keyPair1 = $seed | New-SodiumKeyPair
+            $keyPair2 = $seed | New-SodiumKeyPair
+
+            $keyPair1.PublicKey | Should -Be $keyPair2.PublicKey
+            $keyPair1.PrivateKey | Should -Be $keyPair2.PrivateKey
+        }
+
         It 'Generates different keys for different seeds' {
             $seed1 = 'SeedOne'
             $seed2 = 'SeedTwo'

--- a/tests/Sodium.Tests.ps1
+++ b/tests/Sodium.Tests.ps1
@@ -63,6 +63,35 @@
                 ConvertFrom-SodiumSealedBox -SealedBox $sealedBox -PublicKey $keyPair.PublicKey -PrivateKey $invalidPrivateKey
             } | Should -Throw
         }
+
+        It 'Encrypts a message correctly when using pipeline input on ConvertTo-SodiumSealedBox' {
+            $keyPair = New-SodiumKeyPair
+            $publicKey = $keyPair.PublicKey
+            $privateKey = $keyPair.PrivateKey
+            $message = 'Pipeline input encryption test'
+
+            # Pass the message via pipeline input instead of -Message parameter
+            $sealedBox = $message | ConvertTo-SodiumSealedBox -PublicKey $publicKey
+
+            $decryptedString = ConvertFrom-SodiumSealedBox -SealedBox $sealedBox -PublicKey $publicKey -PrivateKey $privateKey
+
+            $decryptedString | Should -Be $message
+        }
+
+        It 'Decrypts a sealed box correctly when using pipeline input on ConvertFrom-SodiumSealedBox' {
+            $keyPair = New-SodiumKeyPair
+            $publicKey = $keyPair.PublicKey
+            $privateKey = $keyPair.PrivateKey
+            $message = 'Pipeline input decryption test'
+
+            # Encrypt using normal parameter binding
+            $sealedBox = ConvertTo-SodiumSealedBox -Message $message -PublicKey $publicKey
+
+            # Pass the sealed box via pipeline input to the decryption function
+            $decryptedString = $sealedBox | ConvertFrom-SodiumSealedBox -PublicKey $publicKey -PrivateKey $privateKey
+
+            $decryptedString | Should -Be $message
+        }
     }
 
     Context 'Key Pair Generation' {


### PR DESCRIPTION
## Description

This pull request enhances the `Sodium` PowerShell module by adding support for pipeline input to various functions, updating documentation, and adding new tests to ensure proper functionality. The most important changes include the addition of pipeline input support, updates to function documentation, and new tests for pipeline input scenarios.

Enhancements to functions:

* [`src/functions/public/ConvertFrom-SodiumSealedBox.ps1`](diffhunk://#diff-afea5aa86ab4622c3a4bff63aa61976494cb620d338df534bf7121018056bbadL30-R56): Added support for `ValueFromPipeline` and `ValueFromPipelineByPropertyName` to the `SealedBox` parameter.
* [`src/functions/public/ConvertTo-SodiumSealedBox.ps1`](diffhunk://#diff-be3e1727721972ed3d4275a880537b89ce6fbb16c1d97405e02d7e798b6c7bfbL25-R50): Added support for `ValueFromPipeline` and `ValueFromPipelineByPropertyName` to the `Message` parameter.
* [`src/functions/public/New-SodiumKeyPair.ps1`](diffhunk://#diff-b951668ffde5fc1b700af8f8b2b6076d7ce27b0ec23e9d556ad1a893e204c87bL51-R82): Added support for `ValueFromPipeline` to the `Seed` parameter.

Documentation updates:

* [`src/functions/public/ConvertFrom-SodiumSealedBox.ps1`](diffhunk://#diff-afea5aa86ab4622c3a4bff63aa61976494cb620d338df534bf7121018056bbadR18-R41): Enhanced documentation with examples, outputs, and notes for better clarity.
* [`src/functions/public/ConvertTo-SodiumSealedBox.ps1`](diffhunk://#diff-be3e1727721972ed3d4275a880537b89ce6fbb16c1d97405e02d7e798b6c7bfbL11-R35): Enhanced documentation with examples, outputs, and notes for better clarity.
* [`src/functions/public/New-SodiumKeyPair.ps1`](diffhunk://#diff-b951668ffde5fc1b700af8f8b2b6076d7ce27b0ec23e9d556ad1a893e204c87bR40-R62): Enhanced documentation with examples, outputs, and notes for better clarity.

New tests:

* [`tests/Sodium.Tests.ps1`](diffhunk://#diff-f601c73f9a5c51929710c76b4065f37025d3704dae0b299be2a892f7702e6875R66-R94): Added tests to verify encryption and decryption using pipeline input for `ConvertTo-SodiumSealedBox` and `ConvertFrom-SodiumSealedBox`.
* [`tests/Sodium.Tests.ps1`](diffhunk://#diff-f601c73f9a5c51929710c76b4065f37025d3704dae0b299be2a892f7702e6875R116-R124): Added tests to verify deterministic key generation using pipeline input for `New-SodiumKeyPair`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
