### PR TITLE
🩹 [Patch]: Update Dependabot configuration to specify package manifest directory for NuGet

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,6 @@ updates:
     schedule:
       interval: weekly
   - package-ecosystem: nuget # See documentation for possible values
-    directory: / # Location of package manifests
+    directory: /PSModule # Location of package manifests
     schedule:
       interval: weekly


### PR DESCRIPTION
## Description

This pull request includes a small but important change to the `.github/dependabot.yml` file. The change updates the directory location for NuGet package manifests.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L13-R13): Changed the `directory` for the `nuget` package-ecosystem from `/` to `/PSModule` to correctly locate the package manifests.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
