### PR TITLE
⚙️ [Maintenance]: Build now targets .NET 10 LTS with PowerShell 7.6.1

### DIFF
--- a/.github/PSModule.yml
+++ b/.github/PSModule.yml
@@ -2,6 +2,11 @@
 # Reference:
 # - https://github.com/PSModule/Process-PSModule?tab=readme-ov-file#configuration
 
+ImportantFilePatterns:
+  - '^src/'
+  - '^README\.md$'
+  - '^PSModule/'
+
 Test:
   CodeCoverage:
     PercentTarget: 80

--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -27,5 +27,5 @@ permissions:
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@205d193f34cbbaf9992955c21d842bcf98a1859f # v5.4.6
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@e8f5b22925c5a4dcf462d8b212570b66ce6a8df4 # v5.5.2
     secrets: inherit

--- a/PSModule/Sodium.csproj
+++ b/PSModule/Sodium.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <AssemblyName>PSModule.Sodium</AssemblyName>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Management.Automation" Version="7.4.7" PrivateAssets="All" />
+        <PackageReference Include="System.Management.Automation" Version="7.6.1" PrivateAssets="All" />
         <PackageReference Include="libsodium" Version="1.0.22" />
     </ItemGroup>
 

--- a/PSModule/build.ps1
+++ b/PSModule/build.ps1
@@ -19,7 +19,7 @@ try {
             throw "dotnet publish failed for runtime '$_'."
         }
 
-        $source = "$PSScriptRoot/bin/Release/net8.0/$_/publish"
+        $source = "$PSScriptRoot/bin/Release/net10.0/$_/publish"
         $destination = "$PSScriptRoot/../src/libs/$_"
         Copy-Item -Path $source -Destination $destination -Recurse -Force
     }


### PR DESCRIPTION
Sodium now builds against the latest stable .NET 10 LTS runtime and PowerShell SDK 7.6.1, aligning the module toolchain with current platform baselines for ongoing interop hardening and future release validation. The CI pipeline is also updated to recognise the native interop project directory as an important path so that changes there correctly trigger the build, test, and publish stages.

- Fixes #61

## Changed: Build toolchain baseline

The `PSModule.Sodium` project now targets `.NET 10.0`, and the `System.Management.Automation` dependency is updated to `7.6.1`. This keeps the module aligned with current PowerShell runtime expectations and removes the prior fallback to .NET 8-era SDK references.

## Changed: CI build trigger now includes `PSModule/`

The `PSModule/` directory (which contains `Sodium.csproj` and `build.ps1`) is now listed in `ImportantFilePatterns` in `.github/PSModule.yml`. Previously, changes to the native interop project files were classified as non-important by the workflow defaults (`^src/` and `^README\.md$`), causing the build and test stages to be skipped entirely. Adding `^PSModule/` ensures those changes are treated as release-relevant and trigger the full pipeline.

## Technical Details

- Updated `PSModule/Sodium.csproj`:
  - `TargetFramework` changed from `net8.0` to `net10.0`
  - `System.Management.Automation` changed from `7.4.7` to `7.6.1`
- Updated `PSModule/build.ps1` to copy published artifacts from `bin/Release/net10.0/<rid>/publish`.
- Added `ImportantFilePatterns` to `.github/PSModule.yml` with the two default patterns (`^src/`, `^README\.md$`) plus the new `^PSModule/` pattern.
- Implementation plan progress for #61:
  - Completed: project framework and package version updates, CI trigger configuration.
  - Pending: cross-platform test validation and performance comparison against .NET 8 baseline in CI.